### PR TITLE
remove link, won't render on GitHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,4 +3,4 @@ Příručka pro pořadatele - Python v ČR
 
 Tato příručka je komunitní projekt `českých Pythonistů <http://python.cz>`_. Jejím cílem je poskytnout materiály a *know-how* pro pořadatele a částečně i účastníky (např. kouče) různých akcí, jako jsou srazy, workshopy, kurzy.
 
-Příručka je tvořena jako `otevřená <https://cs.wikipedia.org/wiki/Otev%C5%99en%C3%BD_software>`_, do jejího zdrojového kódu a textů :ref:`může kdokoliv navrhovat změny <contributing>`. Texty a obrázky těchto materiálů jsou uvolněny pod licencí `CC BY-SA 4.0 <https://creativecommons.org/licenses/by-sa/4.0/deed.cs>`_. Za touto příručkou stojí `Pyvec <http://pyvec.org/>`_, neziskovka podporující v ČR aktivity kolem programovacího jazyka Python.
+Příručka je tvořena jako `otevřená <https://cs.wikipedia.org/wiki/Otev%C5%99en%C3%BD_software>`_, do jejího zdrojového kódu a textů může kdokoliv navrhovat změny. Texty a obrázky těchto materiálů jsou uvolněny pod licencí `CC BY-SA 4.0 <https://creativecommons.org/licenses/by-sa/4.0/deed.cs>`_. Za touto příručkou stojí `Pyvec <http://pyvec.org/>`_, neziskovka podporující v ČR aktivity kolem programovacího jazyka Python.


### PR DESCRIPTION
The link isn't so necessary as for GitHub readers, the CONTRIBUTING.rst is prominent and known by convention. Also, those on a GitHub repo probably already know they can contribute :)) For RTD HTML readers the link is in the menu.

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/283441/44646870-b20e9700-a9dc-11e8-9138-e1b279619823.png">
